### PR TITLE
assign interpreter per-target

### DIFF
--- a/buildgen/__init__.py
+++ b/buildgen/__init__.py
@@ -44,16 +44,19 @@ def generate_workspace(manifest: Manifest) -> str:
 
 
 def generate_root_build(manifest: Manifest) -> str:
-    language_ids = set()
+    language_ids_to_languages: dict[str, set[Language]] = defaultdict(set)
     languages_to_groups: dict[Language, list[Group]] = defaultdict(list)
     for group in manifest.groups:
-        language_ids.add(group.language.id)
+        language_ids_to_languages[group.language.id].add(group.language)
         languages_to_groups[group.language].append(group)
 
     sections = []
-    for language_id in sorted(language_ids):
+    for language_id, languages in sorted(language_ids_to_languages.items()):
+        # TODO: make it so you can do `sorted` on `Language`. define an ordering function?
+        # NOTE: maintain sort order for testing
+        sorted_languages = list(sorted(languages, key=lambda language: language.value))
         generator = LANGUAGE_TO_GENERATOR[language_id]
-        sections.append(generator.generate_build_rules())
+        sections.append(generator.generate_build_rules(sorted_languages))
 
     for group in manifest.groups:
         generator = LANGUAGE_TO_GENERATOR[group.language.id]

--- a/buildgen/common.py
+++ b/buildgen/common.py
@@ -53,7 +53,7 @@ class BuildGenerator(ABC):
         pass
 
     @abstractmethod
-    def generate_build_rules(self) -> str:
+    def generate_build_rules(self, languages: list[Language]) -> str:
         """\
         Loads the build rules necessary to define endpoints and servers.
         This is typically library rules for endpoints (like `py_library`)

--- a/buildgen/python.py
+++ b/buildgen/python.py
@@ -73,13 +73,17 @@ class PythonBuildGenerator(BuildGenerator):
             interpreter_name=get_interpreter_name(group.language),
         )
 
-    def generate_build_rules(self) -> str:
-        return self.env.get_template("build_rules.jinja2.BUILD").render()
+    def generate_build_rules(self, languages: list[Language]) -> str:
+        template = self.env.get_template("build_rules.jinja2.BUILD")
+        return template.render(
+            toolchain_names=[language.toolchain_name for language in languages],
+        )
 
     def generate_target(self, group: Group) -> str:
         template = self.env.get_template("target.jinja2.BUILD")
         return template.render(
             group_name=group.name,
+            interpreter_name=get_interpreter_name(group.language),
             group_target=filename_as_target(group.filename),
             requirements=load_requirements(group.dependencies),
         )
@@ -88,6 +92,7 @@ class PythonBuildGenerator(BuildGenerator):
         template = self.env.get_template("server_target.jinja2.BUILD")
         return template.render(
             toolchain_name=get_toolchain_name(language),
+            interpreter_name=get_interpreter_name(language),
             groups=[group.name for group in groups],
             requirements=load_requirements("requirements.txt"),
         )

--- a/templates/python/build_rules.jinja2.BUILD
+++ b/templates/python/build_rules.jinja2.BUILD
@@ -1,1 +1,4 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+{% for toolchain_name in toolchain_names %}
+load("@{{ toolchain_name }}//:defs.bzl", {{toolchain_name}}_interpreter = "interpreter")
+{% endfor %}

--- a/templates/python/server_target.jinja2.BUILD
+++ b/templates/python/server_target.jinja2.BUILD
@@ -2,6 +2,7 @@ load("@{{ toolchain_name }}_server_deps//:requirements.bzl", {{ toolchain_name }
 
 py_binary(
     name = "{{ toolchain_name }}_server",
+    interpreter = {{ interpreter_name }},
     srcs = [":{{ toolchain_name }}_server.py"],
     deps = [
         {% for group in groups %}

--- a/templates/python/target.jinja2.BUILD
+++ b/templates/python/target.jinja2.BUILD
@@ -2,6 +2,7 @@ load("@{{ group_name }}_deps//:requirements.bzl", requirement_{{ group_name }} =
 
 py_library(
     name = "{{ group_name }}",
+    interpreter = {{ interpreter_name }},
     srcs = ["{{ group_target }}"],
     deps = [
         {% for requirement in requirements %}

--- a/tests/buildgen/test_python.py
+++ b/tests/buildgen/test_python.py
@@ -76,12 +76,28 @@ def test_python_build_generator__target_deps():
     assert target_deps == expected_target_deps
 
 
-def test_python_build_generator__build_rules():
+def test_python_build_generator__build_rules_single():
     generator = python.PythonBuildGenerator()
-    build_rules = generator.generate_build_rules()
+    build_rules = generator.generate_build_rules([Language.PYTHON_3_10])
 
     expected_build_rules = """\
     load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+    load("@python3_10//:defs.bzl", python3_10_interpreter = "interpreter")
+    """
+    expected_build_rules = textwrap.dedent(expected_build_rules)
+    assert build_rules == expected_build_rules
+
+
+def test_python_build_generator__build_rules__multiple():
+    generator = python.PythonBuildGenerator()
+    build_rules = generator.generate_build_rules(
+        [Language.PYTHON_3_10, Language.PYTHON_3_11]
+    )
+
+    expected_build_rules = """\
+    load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+    load("@python3_10//:defs.bzl", python3_10_interpreter = "interpreter")
+    load("@python3_11//:defs.bzl", python3_11_interpreter = "interpreter")
     """
     expected_build_rules = textwrap.dedent(expected_build_rules)
     assert build_rules == expected_build_rules
@@ -110,6 +126,7 @@ def test_python_build_generator__target(tmp_path):
 
     py_library(
         name = "test",
+        interpreter = python3_10_interpreter,
         srcs = ["//:something.py"],
         deps = [
             requirement_test("somedep"),
@@ -146,6 +163,7 @@ def test_python_build_generator__server_target(tmp_path):
 
     py_binary(
         name = "python3_10_server",
+        interpreter = python3_10_interpreter,
         srcs = [":python3_10_server.py"],
         deps = [
             ":test",

--- a/tests/test_buildgen.py
+++ b/tests/test_buildgen.py
@@ -22,8 +22,9 @@ class MockGenerator(BuildGenerator):
     def generate_target_deps(self, group: Group) -> str:
         return f"mock_target_deps_{group.name}()\n"
 
-    def generate_build_rules(self) -> str:
-        return "mock_build_rules()\n"
+    def generate_build_rules(self, languages: list[Language]) -> str:
+        rendered_languages = ",".join(language.toolchain_name for language in languages)
+        return f"mock_build_rules({rendered_languages})\n"
 
     def generate_target(self, group: Group) -> str:
         return f"mock_target_{group.name}()\n"
@@ -171,7 +172,7 @@ def test_generate_root_build__one_target(use_mock_generator):
     root_build = buildgen.generate_root_build(manifest)
 
     expected_root_build = """\
-    mock_build_rules()
+    mock_build_rules(python3_11)
 
     mock_target_test()
 
@@ -203,7 +204,7 @@ def test_generate_root_build__two_targets_same_language(use_mock_generator):
     root_build = buildgen.generate_root_build(manifest)
 
     expected_root_build = """\
-    mock_build_rules()
+    mock_build_rules(python3_11)
 
     mock_target_test()
 
@@ -237,7 +238,7 @@ def test_generate_root_build__two_targets_different_language(use_mock_generator)
     root_build = buildgen.generate_root_build(manifest)
 
     expected_root_build = """\
-    mock_build_rules()
+    mock_build_rules(python3_10,python3_11)
 
     mock_target_test()
 


### PR DESCRIPTION
Try to assign an `interpreter` per-target for `py_library` and `py_binary` targets. This approach failed because there actually aren't any `interpreter` parameters on rules_python targets.